### PR TITLE
Added root element allows linking to github source

### DIFF
--- a/components/Rollbar.cfc
+++ b/components/Rollbar.cfc
@@ -199,6 +199,7 @@ component output="false"
   {
     return {
       "coldfusion" = server.coldfusion,
+      "root" = "/",
       "os" = server.os
     };
   }


### PR DESCRIPTION
Added root element.

This allows rollbar to link directly to github source.
